### PR TITLE
feature/get event summary

### DIFF
--- a/src/main/java/com/example/eventsync/clients/SentimentApiClient.java
+++ b/src/main/java/com/example/eventsync/clients/SentimentApiClient.java
@@ -1,0 +1,56 @@
+package com.example.eventsync.clients;
+
+import com.example.eventsync.dtos.SentimentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class SentimentApiClient {
+    @Value("${huggingface.api.url}")
+    private String huggingFaceUrl;
+
+    @Value("${huggingface.api.token}")
+    private String huggingFaceToken;
+
+    private final RestTemplate restTemplate;
+
+    public SentimentResponse[][] analyzeMessage(String message) {
+        HttpEntity<Map<String, String>> request = buildHttpRequest(message);
+
+        try{
+            ResponseEntity<SentimentResponse[][]> response = restTemplate.postForEntity(
+                    huggingFaceUrl,
+                    request,
+                    SentimentResponse[][].class
+            );
+
+            if(response.getStatusCode().is2xxSuccessful()){
+                return response.getBody();
+            } else {
+                throw new RuntimeException("Sentiment API returned status: " + response.getStatusCode());
+            }
+        } catch (RestClientException e) {
+            throw new RuntimeException("Failed to call sentiment API", e);
+        }
+    }
+
+    private HttpEntity<Map<String, String>> buildHttpRequest(String message) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.setBearerAuth(huggingFaceToken);
+
+        Map<String, String> body = Collections.singletonMap("inputs", message);
+        return new HttpEntity<>(body, headers);
+    }
+}

--- a/src/main/java/com/example/eventsync/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/eventsync/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.example.eventsync.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/eventsync/controllers/EventController.java
+++ b/src/main/java/com/example/eventsync/controllers/EventController.java
@@ -2,12 +2,15 @@ package com.example.eventsync.controllers;
 
 import com.example.eventsync.dtos.CreateEventRequest;
 import com.example.eventsync.dtos.EventResponse;
+import com.example.eventsync.dtos.EventSentimentSummaryResponse;
+import com.example.eventsync.dtos.SentimentResponse;
 import com.example.eventsync.services.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/events")
@@ -25,5 +28,11 @@ public class EventController {
     @ResponseStatus(HttpStatus.OK)
     public List<EventResponse> getAllEvents() {
         return eventService.getAllEvents();
+    }
+
+    @GetMapping("/{eventId}/summary")
+    @ResponseStatus(HttpStatus.OK)
+    public EventSentimentSummaryResponse getEventSentimentSummary(@PathVariable UUID eventId) {
+        return eventService.getSentimentSummary(eventId);
     }
 }

--- a/src/main/java/com/example/eventsync/dtos/EventSentimentSummaryResponse.java
+++ b/src/main/java/com/example/eventsync/dtos/EventSentimentSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.example.eventsync.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EventSentimentSummaryResponse {
+    private int positiveCount;
+    private int neutralCount;
+    private int negativeCount;
+}

--- a/src/main/java/com/example/eventsync/dtos/FeedbackResponse.java
+++ b/src/main/java/com/example/eventsync/dtos/FeedbackResponse.java
@@ -1,5 +1,6 @@
 package com.example.eventsync.dtos;
 
+import com.example.eventsync.model.SentimentType;
 import lombok.Builder;
 import lombok.Data;
 
@@ -13,4 +14,5 @@ public class FeedbackResponse {
     private UUID eventId;
     private String message;
     private Instant createdAt;
+    private SentimentType sentiment;
 }

--- a/src/main/java/com/example/eventsync/dtos/SentimentCount.java
+++ b/src/main/java/com/example/eventsync/dtos/SentimentCount.java
@@ -1,0 +1,9 @@
+package com.example.eventsync.dtos;
+
+import lombok.Data;
+
+@Data
+public class SentimentCount {
+    private String sentiment;
+    private Integer count;
+}

--- a/src/main/java/com/example/eventsync/dtos/SentimentResponse.java
+++ b/src/main/java/com/example/eventsync/dtos/SentimentResponse.java
@@ -1,0 +1,11 @@
+package com.example.eventsync.dtos;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SentimentResponse {
+    private String label;
+    private double score;
+}

--- a/src/main/java/com/example/eventsync/mapper/EventMapper.java
+++ b/src/main/java/com/example/eventsync/mapper/EventMapper.java
@@ -2,10 +2,14 @@ package com.example.eventsync.mapper;
 
 import com.example.eventsync.dtos.CreateEventRequest;
 import com.example.eventsync.dtos.EventResponse;
+import com.example.eventsync.dtos.EventSentimentSummaryResponse;
+import com.example.eventsync.dtos.SentimentCount;
 import com.example.eventsync.model.Event;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class EventMapper {
     public static Event fromDto(CreateEventRequest request) {
@@ -28,5 +32,16 @@ public class EventMapper {
         return events.stream()
                 .map(EventMapper::toDto)
                 .toList();
+    }
+
+    public static EventSentimentSummaryResponse toSentimentSummary(List<SentimentCount> counts) {
+        Map<String, Integer> sentimentsCount = counts.stream()
+                .collect(Collectors.toMap(SentimentCount::getSentiment, SentimentCount::getCount));
+
+        return EventSentimentSummaryResponse.builder()
+                .positiveCount(sentimentsCount.getOrDefault("POSITIVE", 0))
+                .neutralCount(sentimentsCount.getOrDefault("NEUTRAL", 0))
+                .negativeCount(sentimentsCount.getOrDefault("NEGATIVE", 0))
+                .build();
     }
 }

--- a/src/main/java/com/example/eventsync/mapper/FeedbackMapper.java
+++ b/src/main/java/com/example/eventsync/mapper/FeedbackMapper.java
@@ -3,17 +3,19 @@ package com.example.eventsync.mapper;
 import com.example.eventsync.dtos.CreateFeedbackRequest;
 import com.example.eventsync.dtos.FeedbackResponse;
 import com.example.eventsync.model.Feedback;
+import com.example.eventsync.model.SentimentType;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public class FeedbackMapper {
-    public static Feedback fromDto(CreateFeedbackRequest request, UUID eventId) {
+    public static Feedback fromDto(CreateFeedbackRequest request, UUID eventId, SentimentType sentimentType) {
         return Feedback.builder()
                 .id(UUID.randomUUID())
                 .eventId(eventId)
                 .message(request.getMessage())
                 .createdAt(Instant.now())
+                .sentiment(sentimentType)
                 .build();
     }
 
@@ -23,6 +25,7 @@ public class FeedbackMapper {
                 .eventId(feedback.getEventId())
                 .message(feedback.getMessage())
                 .createdAt(feedback.getCreatedAt())
+                .sentiment(feedback.getSentiment())
                 .build();
     }
 }

--- a/src/main/java/com/example/eventsync/model/Feedback.java
+++ b/src/main/java/com/example/eventsync/model/Feedback.java
@@ -13,4 +13,5 @@ public class Feedback {
     private UUID eventId;
     private String message;
     private Instant createdAt;
+    private SentimentType sentiment;
 }

--- a/src/main/java/com/example/eventsync/model/SentimentType.java
+++ b/src/main/java/com/example/eventsync/model/SentimentType.java
@@ -1,0 +1,7 @@
+package com.example.eventsync.model;
+
+public enum SentimentType {
+    POSITIVE,
+    NEUTRAL,
+    NEGATIVE
+}

--- a/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
+++ b/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Repository;
 @Mapper
 public interface FeedbackRepository {
     @Insert("""
-            INSERT INTO feedbacks (id, event_id, message, created_at)
-            VALUES (#{id}, #{eventId}, #{message}, #{createdAt})
+            INSERT INTO feedbacks (id, event_id, message, created_at, sentiment)
+            VALUES (#{id}, #{eventId}, #{message}, #{createdAt}, #{sentiment})
             """)
     void insertFeedback(Feedback feedback);
 }

--- a/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
+++ b/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
@@ -2,8 +2,13 @@ package com.example.eventsync.repositories;
 
 import com.example.eventsync.model.Feedback;
 import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
 import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.UUID;
 
 @Repository
 @Mapper
@@ -13,4 +18,13 @@ public interface FeedbackRepository {
             VALUES (#{id}, #{eventId}, #{message}, #{createdAt}, #{sentiment})
             """)
     void insertFeedback(Feedback feedback);
+
+    @Select("""
+            SELECT sentiment, COUNT (*)
+            FROM feedbacks
+            WHERE event_id = #{eventId}
+            GROUP BY sentiment
+            """)
+    @MapKey("sentiment")
+    Map<String, Integer> countSentimentsByEvent(UUID eventId);
 }

--- a/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
+++ b/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
@@ -1,5 +1,6 @@
 package com.example.eventsync.repositories;
 
+import com.example.eventsync.dtos.SentimentCount;
 import com.example.eventsync.model.Feedback;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.MapKey;
@@ -7,7 +8,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 import org.springframework.stereotype.Repository;
 
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -20,11 +21,10 @@ public interface FeedbackRepository {
     void insertFeedback(Feedback feedback);
 
     @Select("""
-            SELECT sentiment, COUNT (*)
+            SELECT sentiment, COUNT (*) AS count
             FROM feedbacks
             WHERE event_id = #{eventId}
             GROUP BY sentiment
             """)
-    @MapKey("sentiment")
-    Map<String, Integer> countSentimentsByEventId(UUID eventId);
+    List<SentimentCount> countSentimentsByEventId(UUID eventId);
 }

--- a/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
+++ b/src/main/java/com/example/eventsync/repositories/FeedbackRepository.java
@@ -26,5 +26,5 @@ public interface FeedbackRepository {
             GROUP BY sentiment
             """)
     @MapKey("sentiment")
-    Map<String, Integer> countSentimentsByEvent(UUID eventId);
+    Map<String, Integer> countSentimentsByEventId(UUID eventId);
 }

--- a/src/main/java/com/example/eventsync/services/EventService.java
+++ b/src/main/java/com/example/eventsync/services/EventService.java
@@ -43,13 +43,6 @@ public class EventService {
 
         List<SentimentCount> counts = feedbackRepository.countSentimentsByEventId(eventId);
 
-        Map<String, Integer> sentimentsCount = counts.stream()
-                .collect(Collectors.toMap(SentimentCount::getSentiment, SentimentCount::getCount));
-
-        return EventSentimentSummaryResponse.builder()
-                .positiveCount(sentimentsCount.getOrDefault("POSITIVE", 0))
-                .neutralCount(sentimentsCount.getOrDefault("NEUTRAL", 0))
-                .negativeCount(sentimentsCount.getOrDefault("NEGATIVE", 0))
-                .build();
+        return EventMapper.toSentimentSummary(counts);
     }
 }

--- a/src/main/java/com/example/eventsync/services/EventService.java
+++ b/src/main/java/com/example/eventsync/services/EventService.java
@@ -3,6 +3,7 @@ package com.example.eventsync.services;
 import com.example.eventsync.dtos.CreateEventRequest;
 import com.example.eventsync.dtos.EventResponse;
 import com.example.eventsync.dtos.EventSentimentSummaryResponse;
+import com.example.eventsync.dtos.SentimentCount;
 import com.example.eventsync.mapper.EventMapper;
 import com.example.eventsync.model.Event;
 import com.example.eventsync.repositories.EventRepository;
@@ -15,6 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -39,7 +41,10 @@ public class EventService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found");
         }
 
-        Map<String, Integer> sentimentsCount = feedbackRepository.countSentimentsByEventId(eventId);
+        List<SentimentCount> counts = feedbackRepository.countSentimentsByEventId(eventId);
+
+        Map<String, Integer> sentimentsCount = counts.stream()
+                .collect(Collectors.toMap(SentimentCount::getSentiment, SentimentCount::getCount));
 
         return EventSentimentSummaryResponse.builder()
                 .positiveCount(sentimentsCount.getOrDefault("POSITIVE", 0))

--- a/src/main/java/com/example/eventsync/services/EventService.java
+++ b/src/main/java/com/example/eventsync/services/EventService.java
@@ -2,18 +2,25 @@ package com.example.eventsync.services;
 
 import com.example.eventsync.dtos.CreateEventRequest;
 import com.example.eventsync.dtos.EventResponse;
+import com.example.eventsync.dtos.EventSentimentSummaryResponse;
 import com.example.eventsync.mapper.EventMapper;
 import com.example.eventsync.model.Event;
 import com.example.eventsync.repositories.EventRepository;
+import com.example.eventsync.repositories.FeedbackRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 @AllArgsConstructor
 public class EventService {
     private final EventRepository eventRepository;
+    private final FeedbackRepository feedbackRepository;
 
     public EventResponse createEvent(CreateEventRequest request) {
         Event event = EventMapper.fromDto(request);
@@ -24,5 +31,20 @@ public class EventService {
     public List<EventResponse> getAllEvents() {
         List<Event> events = eventRepository.selectAllEvents();
         return EventMapper.toDtoList(events);
+    }
+
+    public EventSentimentSummaryResponse getSentimentSummary(UUID eventId) {
+        Event event = eventRepository.findById(eventId);
+        if(event == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found");
+        }
+
+        Map<String, Integer> sentimentsCount = feedbackRepository.countSentimentsByEventId(eventId);
+
+        return EventSentimentSummaryResponse.builder()
+                .positiveCount(sentimentsCount.getOrDefault("POSITIVE", 0))
+                .neutralCount(sentimentsCount.getOrDefault("NEUTRAL", 0))
+                .negativeCount(sentimentsCount.getOrDefault("NEGATIVE", 0))
+                .build();
     }
 }

--- a/src/main/java/com/example/eventsync/services/FeedbackService.java
+++ b/src/main/java/com/example/eventsync/services/FeedbackService.java
@@ -1,10 +1,13 @@
 package com.example.eventsync.services;
 
+import com.example.eventsync.clients.SentimentApiClient;
 import com.example.eventsync.dtos.CreateFeedbackRequest;
 import com.example.eventsync.dtos.FeedbackResponse;
+import com.example.eventsync.dtos.SentimentResponse;
 import com.example.eventsync.mapper.FeedbackMapper;
 import com.example.eventsync.model.Event;
 import com.example.eventsync.model.Feedback;
+import com.example.eventsync.model.SentimentType;
 import com.example.eventsync.repositories.EventRepository;
 import com.example.eventsync.repositories.FeedbackRepository;
 import lombok.AllArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 @Service
@@ -19,12 +23,15 @@ import java.util.UUID;
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final EventRepository eventRepository;
+    private final SentimentApiClient sentimentApiClient;
 
     public FeedbackResponse createFeedback(UUID eventId, CreateFeedbackRequest request) {
         Event event = eventRepository.findById(eventId);
         if(event == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found");
         }
+
+        SentimentResponse[] res = sentimentApiClient.analyzeMessage(request.getMessage())[0];
 
         Feedback feedback = FeedbackMapper.fromDto(request, eventId);
         feedbackRepository.insertFeedback(feedback);

--- a/src/main/java/com/example/eventsync/services/FeedbackService.java
+++ b/src/main/java/com/example/eventsync/services/FeedbackService.java
@@ -39,7 +39,7 @@ public class FeedbackService {
 
         SentimentType sentimentType = mapLabelToSentimentType(topSentiment.getLabel());
 
-        Feedback feedback = FeedbackMapper.fromDto(request, eventId);
+        Feedback feedback = FeedbackMapper.fromDto(request, eventId, sentimentType);
         feedbackRepository.insertFeedback(feedback);
         return FeedbackMapper.toDto(feedback);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,7 @@ spring.liquibase.enabled=true
 
 #MyBatis config
 mybatis.type-handlers-package=com.example.eventsync.typehandlers
+
+#Hugging Face API config
+huggingface.api.url=https://api-inference.huggingface.co/models/cardiffnlp/twitter-roberta-base-sentiment
+huggingface.api.token=${HF_API_TOKEN}

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -6,4 +6,5 @@
 
     <include file="db/changelog/changesets/001-create-events-table.xml"/>
     <include file="db/changelog/changesets/002-create-feedbacks-table.xml"/>
+    <include file="db/changelog/changesets/003-add-sentiment-type-to-feedbacks-table.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/003-add-sentiment-type-to-feedbacks-table.xml
+++ b/src/main/resources/db/changelog/changesets/003-add-sentiment-type-to-feedbacks-table.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+      http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.15.xsd">
+
+    <changeSet id="3" author="ksystof.tuzik">
+        <addColumn tableName="feedbacks">
+            <column name="sentiment" type="varchar(20)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
**Summary:**
This PR introduces feedback sentiment analysis for events by adding sentiment tracking to feedback entries and exposing a summary endpoint. The goal is to enable quick insight into the overall attendee mood per event (positive/neutral/negative).

**Key changes:**
1. Created an enum _SentimentType_ (_POSITIVE_, _NEUTRAL_, _NEGATIVE_)
2. Added a new column _sentiment_ (VARCHAR) to the _feedbacks_ table.
3. Updated feedback insert operation to include the sentiment value.
4. Adjusted the domain model and mapper to support the sentiment property.
5. Created new DTOs: SentimentCount (sentiment, count); _EventSentimentSummaryResponse_ (with fields: _positiveCount_, _neutralCount_, _negativeCount_).
6. Introduced SQL query in _FeedbackRepository_ to count feedbacks grouped by sentiment for a given event.
7. Service logic added to retrieve counts.
8. Delegate SentimentCount list-to-response mapping to _EventMapper_.
9. Added endpoint GET /events/{eventId}/summary to _EventController_, returning sentiment breakdown for the selected event.